### PR TITLE
feat(driver/git): checkout branch, tag, commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A minimal `sourceknight.yaml` might look something like this:
 ```yaml
 project:
   name: myplugin-example
-  sourceknight: 0.2
+  sourceknight: 0.3
   dependencies:
     - name: sourcemod
       type: tar

--- a/example/sourceknight.yaml
+++ b/example/sourceknight.yaml
@@ -1,5 +1,5 @@
 project:
-  sourceknight: 0.2
+  sourceknight: 0.3
   name: myplugin-example
   dependencies:
     - name: sourcemod

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name="sourceknight",
-    version="0.2",
+    version="0.3",
     author="travis mick",
     author_email="root@lo.calho.st",
     description="simple dependency manager for sourcemod projects",

--- a/sourceknight/drivers/git.py
+++ b/sourceknight/drivers/git.py
@@ -26,9 +26,11 @@ class gitdriver (basedriver):
             logging.info(' Cloning from {:s}'.format(self._model.params['repo']))
             repo = git.Repo.clone_from(self._model.params['repo'], loc)
 
-        # TODO: handle branches, tags, etc
         if self._model.version is None:
             self._model.version = repo.head.commit.hexsha
+        else:
+            repo.git.checkout(self._model.version)
+
         self._ctx._state.update(dependencies={
             self._model.name: self._model.state(location=os.path.relpath(loc, self._ctx._path), driver='git')
         })


### PR DESCRIPTION
This allows us to have this kind of config:

```
    - name: smlib
      type: git
      repo: https://github.com/bcserv/smlib
      version: transitional_syntax
      unpack:
      - source: /scripting/include
        dest: /addons/sourcemod/scripting/include

```